### PR TITLE
Remove writing proxies to disk

### DIFF
--- a/benchmarks/PhpDiBench.php
+++ b/benchmarks/PhpDiBench.php
@@ -26,12 +26,6 @@ class PhpDiBench extends ContainerBenchCase
         return $builder;
     }
 
-    public static function warmup()
-    {
-        $builder = self::createBuilder();
-        $builder->writeProxiesToFile(true, 'tmp/proxies');
-    }
-
     public function initOptimized()
     {
         $builder = self::createBuilder();

--- a/benchmarks/PhpDiBench.php
+++ b/benchmarks/PhpDiBench.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Cache\FilesystemCache;
 
 /**
  * @Groups({"php-di"}, extend=true)
- * @BeforeClassMethods({"clearCache", "warmup"})
+ * @BeforeClassMethods({"clearCache"})
  */
 class PhpDiBench extends ContainerBenchCase
 {


### PR DESCRIPTION
This method call doesn't write anything to disk, it's just setting up a configuration value. Additionally since you don't use lazy loading, PHP-DI doesn't use proxies at all (you'd need to install Ocramius/ProxyManager in that case). So this line can be removed.
